### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1958,6 +1959,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2015,6 +2026,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.6.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "dompurify": "^3.1.6",
         "framer-motion": "^11.5.5",
         "next": "14.2.12",
         "react": "^18",
@@ -2891,6 +2892,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "framer-motion": "^11.5.5",
     "next": "14.2.12",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "dompurify": "^3.1.6"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,13 +13,14 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "dompurify": "^3.1.6",
     "framer-motion": "^11.5.5",
     "next": "14.2.12",
     "react": "^18",
-    "react-dom": "^18",
-    "dompurify": "^3.1.6"
+    "react-dom": "^18"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/frontend/src/app/ui/snippets/gear-parser.tsx
+++ b/frontend/src/app/ui/snippets/gear-parser.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import styles from "./gear-parser.module.css";
 import { useState } from "react";
+import DOMPurify from "dompurify";
 
 interface GearParserProps {
   isVisible: boolean;
@@ -155,7 +156,7 @@ export function GearParser(props: GearParserProps) {
                 border: `${gear.active ? "1px solid green" : "1px solid blue"}`,
               }}
             >
-              <a href={gear.link} target="_blank">
+              <a href={DOMPurify.sanitize(gear.link)} target="_blank">
                 <Image
                   aria-hidden
                   src={gear.image}


### PR DESCRIPTION
Fixes [https://github.com/alexohneander/sim_free/security/code-scanning/1](https://github.com/alexohneander/sim_free/security/code-scanning/1)

To fix the problem, we need to ensure that the `gear.link` value is properly sanitized before being used in the `href` attribute. This can be achieved by using a library like `DOMPurify` to sanitize the URL, ensuring that any potentially malicious content is removed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the relevant file.
3. Sanitize the `gear.link` value before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
